### PR TITLE
Rename n contacts to cumulative contact duration in agents.py

### DIFF
--- a/citam/engine/core/agent.py
+++ b/citam/engine/core/agent.py
@@ -54,7 +54,7 @@ class Agent:
         self.office_id = office_id
         self.job_function = job_function
 
-        self.n_contacts = 0
+        self.cumulative_contact_duration = 0
         self.pos = None
         self.current_location = None
         self.current_floor = None

--- a/citam/engine/core/simulation.py
+++ b/citam/engine/core/simulation.py
@@ -518,8 +518,8 @@ class Simulation:
         dx = (agent2.pos[0] - agent1.pos[0]) / 2.0
         dy = (agent2.pos[1] - agent1.pos[1]) / 2.0
         contact_pos = (agent1.pos[0] + dx, agent1.pos[1] + dy)
-        agent1.n_contacts += 1
-        agent2.n_contacts += 1
+        agent1.cumulative_contact_duration += 1
+        agent2.cumulative_contact_duration += 1
         self.contact_events.add_contact(
             agent1, agent2, self.current_step, contact_pos
         )
@@ -578,7 +578,7 @@ class Simulation:
                     + "\t"
                     + str(agent.current_floor)
                     + "\t"
-                    + str(agent.n_contacts)
+                    + str(agent.cumulative_contact_duration)
                     + "\n"
                 )
 
@@ -639,7 +639,7 @@ class Simulation:
         agent_ids, n_contacts = [], []
         for unique_id, agent in self.agents.items():
             agent_ids.append("ID_" + str(unique_id + 1))
-            n_contacts.append(agent.n_contacts)
+            n_contacts.append(agent.cumulative_contact_duration)
 
         return agent_ids, n_contacts
 

--- a/citam/tests/engine/test_simulation.py
+++ b/citam/tests/engine/test_simulation.py
@@ -155,8 +155,8 @@ def test_identify_contacts_wall_seperation(simple_facility_model):
     assert len(model.contact_events.contact_data) == 0
     assert len(model.step_contact_locations) == 1
     assert len(model.step_contact_locations[0]) == 0
-    assert agent1.n_contacts == 0
-    assert agent2.n_contacts == 0
+    assert agent1.cumulative_contact_duration == 0
+    assert agent2.n_contcumulative_contact_durationacts == 0
 
 
 def test_identify_contacts_3_way(simple_facility_model):
@@ -183,9 +183,9 @@ def test_identify_contacts_3_way(simple_facility_model):
 
     assert len(model.contact_events.contact_data) == 3
     assert len(model.step_contact_locations[0]) == 3
-    assert agent1.n_contacts == 2
-    assert agent2.n_contacts == 2
-    assert agent3.n_contacts == 2
+    assert agent1.cumulative_contact_duration == 2
+    assert agent2.cumulative_contact_duration == 2
+    assert agent3.cumulative_contact_duration == 2
 
     for key, contact_pos in zip(["1-2", "1-3", "2-3"], contact_positions):
         assert key in model.contact_events.contact_data
@@ -219,8 +219,8 @@ def test_add_contact_event(simple_facility_model):
     assert len(model.step_contact_locations) == 1
     assert contact_pos in model.step_contact_locations[0]
     assert model.step_contact_locations[0][contact_pos] == 1
-    assert agent1.n_contacts == 1
-    assert agent2.n_contacts == 1
+    assert agent1.cumulative_contact_duration == 1
+    assert agent2.cumulative_contact_duration == 1
 
 
 def test_step(simple_facility_model):

--- a/citam/tests/engine/test_simulation.py
+++ b/citam/tests/engine/test_simulation.py
@@ -156,7 +156,7 @@ def test_identify_contacts_wall_seperation(simple_facility_model):
     assert len(model.step_contact_locations) == 1
     assert len(model.step_contact_locations[0]) == 0
     assert agent1.cumulative_contact_duration == 0
-    assert agent2.n_contcumulative_contact_durationacts == 0
+    assert agent2.cumulative_contact_duration == 0
 
 
 def test_identify_contacts_3_way(simple_facility_model):


### PR DESCRIPTION
The n_contacts property in agent.py is misleading. It doesn't actually count the number of contacts as it is incremented every step the agent is within contact distance of another agent. The name is changed to cumulative_contact_duration to better match what it actually represents.