### PR TITLE
Update Vue cli packges

### DIFF
--- a/citamjs/package.json
+++ b/citamjs/package.json
@@ -32,10 +32,10 @@
     "vuex": "^3.6.0"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "^4.5.13",
-    "@vue/cli-plugin-eslint": "^4.5.13",
-    "@vue/cli-plugin-unit-jest": "^4.5.13",
-    "@vue/cli-service": "^4.5.13",
+    "@vue/cli-plugin-babel": "4.5.16",
+    "@vue/cli-plugin-eslint": "4.5.16",
+    "@vue/cli-plugin-unit-jest": "4.5.16",
+    "@vue/cli-service": "4.5.16",
     "@vue/test-utils": "^1.0.3",
     "babel-eslint": "^10.1.0",
     "babel-plugin-lodash": "^3.3.4",


### PR DESCRIPTION
Update vue-cli packages to 4.5.16 to fix protestware introduced in node-ipc (vue-cli dependency)